### PR TITLE
Remove snippets duplicated with core language-python

### DIFF
--- a/snippets/django-atom.cson
+++ b/snippets/django-atom.cson
@@ -299,12 +299,6 @@
   "__init__":
     prefix: "init"
     body: "__init__(self, *args, **kwargs)"
-  "ipdb":
-    prefix: "ipdb"
-    body: "ipdb.set_trace()"
-  "pdb":
-    prefix: "pdb"
-    body: "pdb.set_trace()"
   "Send Mail":
     prefix: "sendmail"
     body: '''


### PR DESCRIPTION
I removed pdb&ipdb django-atom, which were already in `language-python`, and `language-python` provides more appropriate content.
