### PR TITLE
Add url snippet, was missing

### DIFF
--- a/snippets/django-atom.cson
+++ b/snippets/django-atom.cson
@@ -450,6 +450,9 @@
   trans:
     prefix: "trans"
     body: "{% trans \"${1:string to translate}\" %}$0"
+  url:
+    prefix: 'url'
+    body: "{% url %}"
   variable:
     prefix: "var"
     body: "{{ $1 }}$0"


### PR DESCRIPTION
The url snippet wasn't working, so I added the lines 
  url:
    prefix: 'url'
    body: "{% url %}"

to this file. Works in my computer