### PR TITLE
fix for: snippet autocomplete not working #11

### DIFF
--- a/grammars/html (django).cson
+++ b/grammars/html (django).cson
@@ -1,7 +1,7 @@
 {
   name: "HTML (Django Template)",
   scopeName: "text.html.django",
-  fileTypes: ["html", "djhtml],
+  fileTypes: ["html"],
   patterns: [
     {
       name: "comment.block.django",

--- a/snippets/django-atom.cson
+++ b/snippets/django-atom.cson
@@ -1,4 +1,4 @@
-".source.python.django":
+".source.python":
   # Model fields
 
   "Model AutoField":
@@ -311,7 +311,7 @@
     prefix: "url"
     body: "url(regex=r'^${1:URLPARENT}/$', view=${1:VIEW}, name='${3:URLNAME}'),$0"
 
-".text.html.django":
+".text.html":
   autoescape:
     prefix: "autoescape"
     body: '''


### PR DESCRIPTION
Snippets autocomplete weren't working for me. But removing the django tags helps.